### PR TITLE
AllocatorHandle + HeapCompactionNodeHandle

### DIFF
--- a/config/S72E01/splits.txt
+++ b/config/S72E01/splits.txt
@@ -503,6 +503,9 @@ donut/hid/Stick.cpp:
 	.text       start:0x801A4778 end:0x801A4810
 	.sdata2     start:0x8055F930 end:0x8055F938
 
+donut/mem/AllocatorHandle.cpp:
+	.text       start:0x801BD204 end:0x801BD204
+
 donut/mem/DataBlock.cpp:
 	.text       start:0x801BD2A4 end:0x801BD370
 
@@ -511,6 +514,9 @@ donut/mem/GlobalNewDeleteChanger.cpp:
 
 donut/mem/HeapCompactionNode.cpp:
 	.text       start:0x801BE1F8 end:0x801BE2A8
+
+donut/mem/HeapCompactionNodeHandle.cpp:
+	.text       start:0x801BE2A8 end:0x801BE2B0
 
 donut/mem/HeapExp.cpp:
 	.text       start:0x801BE2B0 end:0x801BE640

--- a/configure.py
+++ b/configure.py
@@ -631,6 +631,8 @@ config.libs = [
         "progress_category": "donut",
         "objects": [
             Object(Matching, "donut/mem/DataBlock.cpp"),
+            Object(Matching, "donut/mem/HeapCompactionNodeHandle.cpp", extra_cflags=["-O3,s"]),
+            Object(Matching, "donut/mem/AllocatorHandle.cpp", extra_cflags=["-O3,s"]),
             Object(Matching, "donut/mem/GlobalNewDeleteChanger.cpp", extra_cflags=["-O3,s"]),
             Object(NonMatching, "donut/mem/HeapCompactionNode.cpp", extra_cflags=["-O3,s"]),
             Object(NonMatching, "donut/mem/HeapExp.cpp", extra_cflags=["-O3,s"]),

--- a/src/donut/mem/AllocatorHandle.cpp
+++ b/src/donut/mem/AllocatorHandle.cpp
@@ -1,0 +1,24 @@
+#pragma peephole off
+#include <donut/mem/AllocatorHandle.hpp>
+#include <donut/mem/IAllocator.hpp>
+
+//NOTE: This whole TU is quite literally only comprised of code merged functions.
+//Refer to the header for more details.
+
+namespace mem {
+    AllocatorHandle::AllocatorHandle()
+        : mAllocator(0)
+    { }
+
+    AllocatorHandle::AllocatorHandle(IAllocator& rAllocator)
+        : mAllocator(&rAllocator)
+    { }
+
+    bool AllocatorHandle::isValid() const {
+        return mAllocator != nullptr;
+    }
+
+    IAllocator* AllocatorHandle::obj() const {
+        return mAllocator;
+    }
+};

--- a/src/donut/mem/AllocatorHandle.hpp
+++ b/src/donut/mem/AllocatorHandle.hpp
@@ -1,0 +1,29 @@
+#ifndef DONUT_MEM_ALLOCATOR_HANDLE_HPP
+#define DONUT_MEM_ALLOCATOR_HANDLE_HPP
+
+#include <types.h>
+
+namespace mem {
+class IAllocator;
+
+class AllocatorHandle {
+public:
+    //NOTE: Merged into nw4r::g3d::LightObj::LightObj()
+    AllocatorHandle();
+    //NOTE: Merged into nw4r::g3d::Camera::Camera(nw4r::g3d::CameraData*)
+    AllocatorHandle(IAllocator& rAllocator);
+
+    //TODO: Does this exist?
+    ~AllocatorHandle();
+
+    //NOTE: Merged into nrel::mem::ExpHeapBlockIterator::hasNext() const
+    bool isValid() const;
+
+    //NOTE: Merged into GKI_getfirst
+    IAllocator* obj() const;
+
+    /* 0x0 */ IAllocator* mAllocator;
+};
+}
+
+#endif

--- a/src/donut/mem/HeapCompactionNodeHandle.cpp
+++ b/src/donut/mem/HeapCompactionNodeHandle.cpp
@@ -1,0 +1,26 @@
+#pragma peephole off
+#include <donut/mem/HeapCompactionNodeHandle.hpp>
+#include <donut/mem/HeapCompactionNode.hpp>
+
+namespace mem {
+
+    MemBlock HeapCompactionNodeHandle::block() const {
+        return mNode->block();
+    }
+    //NOTE: All functions below are code merged into others. Refer to the header for more details
+    HeapCompactionNodeHandle::HeapCompactionNodeHandle()
+        : mNode(0)
+    { }
+
+    HeapCompactionNodeHandle::HeapCompactionNodeHandle(HeapCompactionNode& rNode)
+        : mNode(&rNode)
+    { }
+
+    bool HeapCompactionNodeHandle::isValid() const {
+        return mNode != nullptr;
+    }
+
+    HeapCompactionNode* HeapCompactionNodeHandle::node() const {
+        return mNode;
+    }
+};

--- a/src/donut/mem/HeapCompactionNodeHandle.hpp
+++ b/src/donut/mem/HeapCompactionNodeHandle.hpp
@@ -1,0 +1,31 @@
+#ifndef DONUT_MEM_HEAP_COMPACTION_NODE_HANDLE_HPP
+#define DONUT_MEM_HEAP_COMPACTION_NODE_HANDLE_HPP
+
+#include <donut/mem/MemBlock.hpp>
+
+namespace mem {
+class HeapCompactionNode;
+
+class HeapCompactionNodeHandle {
+public:
+    //NOTE: Merged into nw4r::g3d::LightObj::LightObj()
+    HeapCompactionNodeHandle();
+    //NOTE: Merged into nw4r::g3d::Camera::Camera(nw4r::g3d::CameraData*)
+    HeapCompactionNodeHandle(HeapCompactionNode& rNode);
+
+    //TODO: Does this exist?
+    ~HeapCompactionNodeHandle();
+
+    //NOTE: Merged into nrel::mem::ExpHeapBlockIterator::hasNext() const
+    bool isValid() const;
+
+    //NOTE: Merged into GKI_getfirst
+    HeapCompactionNode* node() const;
+
+    MemBlock block() const;
+
+    /* 0x0 */ HeapCompactionNode* mNode;
+};
+}
+
+#endif


### PR DESCRIPTION
Now you may be wondering:

"Hey, why does this PR include two TU's done even though it was made explicitly clear that only ONE should be done per PR to allow other people to work on the namespaces?"

Well the answer is this:
All of AllocatorHandle is code merged so I felt like submitting a PR which would have 0 new matches would just be meh.

So I decided to include HeapCompactionNodeHandle which is 90% code merged besides HeapCompactionNodeHandle::block

its all technically matching but all except block are code merged so yeah
